### PR TITLE
Fix bug in js for restoremailbox

### DIFF
--- a/exchange.php
+++ b/exchange.php
@@ -1204,7 +1204,7 @@ function restoreToOriginal(itemid, type) {
 									itemid = node[0].data.folderid;
 								} else {
 									var act = 'restoremailbox';
-                                    var mailboxid = itemid;
+									var mailboxid = itemid;
 								}
 								
 								var json = '{ "restoretoOriginallocation": \

--- a/exchange.php
+++ b/exchange.php
@@ -1204,6 +1204,7 @@ function restoreToOriginal(itemid, type) {
 									itemid = node[0].data.folderid;
 								} else {
 									var act = 'restoremailbox';
+                                    var mailboxid = itemid;
 								}
 								
 								var json = '{ "restoretoOriginallocation": \


### PR DESCRIPTION
# Pull Request Template

By contributing, you agree that your contributions will be licensed under the projects original open source license.

## Description

For this action it appears that the mailboxid is the itemid, and that's
the only additional argument required for the underlying method
`VBO::restoreMailbox()`.

This surfaced as a javascript error due to the variable being undefined.

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### How Has This Been Tested?

Start session for latest (or any) restore point, go to the exchange section, click on an account, and in the dropdown select "Restore to original location"

### Checklist (check all applicable):

* [x] My code follows the style guidelines of this project
* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in _hard to understand_ areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
